### PR TITLE
Close #23 : LocalDateTime tests sometimes fail

### DIFF
--- a/src/test/java/com/doras/web/stellight/api/domain/schedule/ScheduleRepositoryTest.java
+++ b/src/test/java/com/doras/web/stellight/api/domain/schedule/ScheduleRepositoryTest.java
@@ -127,7 +127,7 @@ public class ScheduleRepositoryTest {
         //then
         Schedule schedule = scheduleList.get(0);
 
-        assertThat(schedule.getCreatedDateTime()).isAfter(now);
-        assertThat(schedule.getModifiedDateTime()).isAfter(now);
+        assertThat(schedule.getCreatedDateTime()).isAfterOrEqualTo(now);
+        assertThat(schedule.getModifiedDateTime()).isAfterOrEqualTo(now);
     }
 }

--- a/src/test/java/com/doras/web/stellight/api/domain/user/BanRepositoryTest.java
+++ b/src/test/java/com/doras/web/stellight/api/domain/user/BanRepositoryTest.java
@@ -61,6 +61,6 @@ public class BanRepositoryTest {
         assertThat(banFound.getId()).isEqualTo(ban.getId());
         assertThat(banFound.getUsers().getId()).isEqualTo(user.getId());
         assertThat(banFound.getReason()).isEqualTo(reason);
-        assertThat(banFound.getCreatedDateTime()).isAfter(now);
+        assertThat(banFound.getCreatedDateTime()).isAfterOrEqualTo(now);
     }
 }

--- a/src/test/java/com/doras/web/stellight/api/domain/user/UsersRepositoryTest.java
+++ b/src/test/java/com/doras/web/stellight/api/domain/user/UsersRepositoryTest.java
@@ -54,7 +54,7 @@ public class UsersRepositoryTest {
         assertThat(userFound.getId()).isEqualTo(user.getId());
         assertThat(userFound.getSnsId()).isEqualTo(snsId);
         assertThat(userFound.getRole()).isEqualTo(role);
-        assertThat(userFound.getCreatedDateTime()).isAfter(now);
+        assertThat(userFound.getCreatedDateTime()).isAfterOrEqualTo(now);
     }
 
     /**

--- a/src/test/java/com/doras/web/stellight/api/web/SchedulesControllerTest.java
+++ b/src/test/java/com/doras/web/stellight/api/web/SchedulesControllerTest.java
@@ -294,7 +294,7 @@ public class SchedulesControllerTest {
                 .andExpect(content().string(String.valueOf(scheduleId)));
         Schedule deletedSchedule = scheduleRepository.findById(scheduleId).orElseThrow();
         assertThat(deletedSchedule.getIsDeleted()).isEqualTo(true);
-        assertThat(deletedSchedule.getModifiedDateTime()).isAfter(now);
+        assertThat(deletedSchedule.getModifiedDateTime()).isAfterOrEqualTo(now);
     }
 
     /**

--- a/src/test/java/com/doras/web/stellight/api/web/UsersControllerTest.java
+++ b/src/test/java/com/doras/web/stellight/api/web/UsersControllerTest.java
@@ -137,7 +137,7 @@ public class UsersControllerTest {
         Ban savedBan = banRepository.findAll().get(0);
         assertThat(savedBan.getUsers().getId()).isEqualTo(userId);
         assertThat(savedBan.getReason()).isEqualTo(reason);
-        assertThat(savedBan.getCreatedDateTime()).isAfter(now);
+        assertThat(savedBan.getCreatedDateTime()).isAfterOrEqualTo(now);
     }
 
     /**


### PR DESCRIPTION
# What is done
- Changed `isAfter(LocalDateTime)` method to `isAfterOrEqualTo(LocalDateTime)` method.