### PR TITLE
Close #40 : Schedules findAll filter doesn't work

### DIFF
--- a/src/main/java/com/doras/web/stellight/api/web/dto/ScheduleFindAllRequestDto.java
+++ b/src/main/java/com/doras/web/stellight/api/web/dto/ScheduleFindAllRequestDto.java
@@ -2,7 +2,6 @@ package com.doras.web.stellight.api.web.dto;
 
 import lombok.Builder;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
@@ -10,24 +9,23 @@ import java.time.LocalDateTime;
  * DTO with filters used when finding all schedules.
  */
 @Getter
-@NoArgsConstructor
 public class ScheduleFindAllRequestDto {
     /**
      * ID of stellar.
      */
-    private Long[] stellarId;
+    private final Long[] stellarId;
 
     /**
      * a filter that means
      * {@link com.doras.web.stellight.api.domain.schedule.Schedule}{@code #startDateTime} is before than this.
      */
-    private LocalDateTime startDateTimeBefore;
+    private final LocalDateTime startDateTimeBefore;
 
     /**
      * a filter that means
      * {@link com.doras.web.stellight.api.domain.schedule.Schedule}{@code #startDateTime} is after than this.
      */
-    private LocalDateTime startDateTimeAfter;
+    private final LocalDateTime startDateTimeAfter;
 
     @Builder
     public ScheduleFindAllRequestDto(Long[] stellarId, LocalDateTime startDateTimeBefore, LocalDateTime startDateTimeAfter) {

--- a/src/test/java/com/doras/web/stellight/api/service/schedule/ScheduleServiceTest.java
+++ b/src/test/java/com/doras/web/stellight/api/service/schedule/ScheduleServiceTest.java
@@ -347,7 +347,7 @@ public class ScheduleServiceTest {
                 .remark("스케줄 비고 2")
                 .build());
 
-        ScheduleFindAllRequestDto requestDto = new ScheduleFindAllRequestDto();
+        ScheduleFindAllRequestDto requestDto = ScheduleFindAllRequestDto.builder().build();
 
         // when
         List<ScheduleResponseDto> result = scheduleService.findAllSchedules(requestDto);


### PR DESCRIPTION
# Bug Details
Filters of `findAll` method of `Schedules` API don't work.

# Reason
When `ScheduleFindAllRequestDto` is created in controller, all fields of the object is `null`.

# Solution
Removed no argument constructor of `ScheduleFindAllRequestDto`.